### PR TITLE
Fix typo in BDD100K dataset link

### DIFF
--- a/docs/source/dataset_links/bdd100k.rst
+++ b/docs/source/dataset_links/bdd100k.rst
@@ -1,3 +1,3 @@
-Dataset Card - Monthly German Tweets
+Dataset Card - Berkeley Deep Drive Semantic Segmentation (BDD100K)
 =====================================
 .. include:: ../../../src/squirrel_datasets_core/datasets/bdd100k/README.rst


### PR DESCRIPTION
# Description

The header for the BDD100K dataset link is incorrect, the PR fixes it.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [ ] I have read the [contributing guideline doc](https://squirrel-datasets-core.readthedocs.io/en/latest/code_of_conduct.html) (external contributors only)
- [x] Lint and unit tests pass locally with my changes
- [x] I have kept the PR small so that it can be easily reviewed  
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All dependency changes have been reflected in the pip requirement files. 
