### PR TITLE
Add pre-commit hooks for jupyter notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,4 +71,4 @@ repos:
     rev: 0.6.0
     hooks:
       - id: nbstripout
-      - stages: [push]
+        stages: [push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,31 +31,6 @@ repos:
       - id: yamllint # Check YAML Files
         args: ["-d", "{extends: relaxed, rules: {line-length: {max: 120 }}}"]
         additional_dependencies: ["--index-url=https://pypi.org/simple/"]
-  - repo: local
-    hooks: # Not nice
-      - id: terraform-version
-        name: Check if terraform v1.0.4 is installed correctly. If this fails, check your version with `terraform --version`
-        language: system
-        entry: bash -c "exit $(terraform --version | sed -n 1p | sed 's/Terraform v//;q' | grep -qE '^\s*1.0.4\s*$')"
-        files: (\.tf|\.tfvars)$ # Only run if there actually are tf files to lint!
-        exclude: \.terraform\/.*$
-        pass_filenames: false
-        require_serial: true
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.60.0
-    hooks:
-      - id: terraform_fmt
-        args:
-          - "--args=-diff"
-  - repo: https://github.com/sqlfluff/sqlfluff
-    rev: 0.4.0 # Oldest version with pre-commit hooks!
-    hooks:
-      - id: sqlfluff-lint
-        args: ["--dialect", "ansi"]
-        additional_dependencies: ["--index-url=https://pypi.org/simple/"]
-      - id: sqlfluff-fix
-        args: ["--dialect", "ansi"]
-        additional_dependencies: ["--index-url=https://pypi.org/simple/"]
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
@@ -71,4 +46,4 @@ repos:
     rev: 0.6.0
     hooks:
       - id: nbstripout
-        stages: [push]
+        additional_dependencies: ["--index-url=https://pypi.org/simple/"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,3 +67,8 @@ repos:
     hooks:
       - id: flake8-nb # Lint jupyter notebooks
         additional_dependencies: ["--index-url=https://pypi.org/simple/"]
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.6.0
+    hooks:
+      - id: nbstripout
+      - stages: [push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     hooks:
       - id: flake8-nb # Lint jupyter notebooks
         additional_dependencies: ["--index-url=https://pypi.org/simple/"]
-  - repo: https://github.com/kynan/nbstripout
+  - repo: https://github.com/pzdkn/mirror-nbstripout
     rev: 0.6.0
     hooks:
       - id: nbstripout


### PR DESCRIPTION
# Description

We have our example notebooks in the sq-ds-core repo. To standardize notebook outputs, prevent private information leakage, and reduce PR diffs, we can introduce an nbstripout precommit hook.

Fixes # issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [ ] I have read the [contributing guideline doc](https://squirrel-datasets-core.readthedocs.io/en/latest/code_of_conduct.html) (external contributors only)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have kept the PR small so that it can be easily reviewed  
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependency changes have been reflected in the pip requirement files. 
