### PR TITLE
Fixed download of california housing dataset

### DIFF
--- a/src/squirrel_datasets_core/datasets/california_housing/driver.py
+++ b/src/squirrel_datasets_core/datasets/california_housing/driver.py
@@ -50,15 +50,17 @@ class CaliforniaHousing(IterDriver):
             urllib.request.urlretrieve(download_url, archive_filepath)
 
             with tarfile.open(mode="r:gz", name=archive_filepath) as f:
-                cal_housing = pd.read_csv(
+                calif_housing = pd.read_csv(
                     f.extractfile("CaliforniaHousing/cal_housing.data"), 
                     index_col=None,
                     header=None,
                     names=_FEATURE_NAMES,
-                ).to_csv(local_filepath, index=False)
+                )
+                calif_housing.to_csv(local_filepath, index=False)
+                self._data = calif_housing.to_dict(orient="records")
             os.remove(archive_filepath)
         else:
-            cal_housing = pd.read_csv(local_filepath).to_dict(orient="records")
+            self._data = pd.read_csv(local_filepath).to_dict(orient="records")
 
     def get_iter(self, shuffle_item_buffer: int = 100, **kwargs) -> Composable:
         """

--- a/src/squirrel_datasets_core/datasets/california_housing/driver.py
+++ b/src/squirrel_datasets_core/datasets/california_housing/driver.py
@@ -71,5 +71,6 @@ class CaliforniaHousing(IterDriver):
         return IterableSource(self._data).shuffle(size=shuffle_item_buffer)
 
 
+
 if __name__ == "__main__":
     CaliforniaHousing()


### PR DESCRIPTION
Fixed a bug in the California housing dataset that was caused by the source .tar file containing two files in the directory. The solution implemented is similar to how sklearn implements fetching the cal-housing dataset. I added a cache in the users home directory to avoid multiple downloads. Theoretically you could also just use a temp directory, but that would mean that the dataset is downloaded multiple times, which is very annoying for testing and debugging. 

Link to sklearn implementation: 
https://github.com/scikit-learn/scikit-learn/blob/364c77e04/sklearn/datasets/_california_housing.py\#L53